### PR TITLE
New approach to image generation with pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,12 @@ PDF417 Barcode Generator (alpha, currently supports only text-mode)
 ```
 from pdf417 import PDF417
 pdf = PDF417('This is the text sample which will be converted to barcode')
-pdf.save_to_png('mybarcode.png')
+pdf.save_to_image_file('mybarcode.png')
+```
+
+# Known bugs
+
+```
+Non-ASCII text will probably return invalid bar code
+Text shorter than 5 characters will probably return invalid bar code
 ```

--- a/pdf417.py
+++ b/pdf417.py
@@ -555,7 +555,7 @@ class PDF417(object):
             if seq[1] > 0:
                 prevseq = code[offset:seq[1]-offset]
 
-                # search from TAB to ~ accroding to ASCII table
+                # search from TAB to ~ according to ASCII table
                 textseq = re.findall('([\x09\x0a\x0d\x20-\x7e]{5,})', prevseq)
 
                 for n in range(0, len(textseq)):
@@ -718,6 +718,7 @@ class PDF417(object):
         return self.barcode_array
 
     def save_to_png(self, filename):
+        """create png image with barcode inside and save to file"""
         bh = 2
         bw = 2
         y = 0
@@ -739,3 +740,37 @@ class PDF417(object):
             y += bh
 
         im.save(filename)
+
+    def save_barcode_to_pillow(self, scale_x=1, scale_y=1):
+        """create pillow image with barcode inside"""
+
+        # creating a black and while 1-BIT image
+        # note: if you have problems with 1-BIT images
+        # select image type "L" and set color=255 for a greyscale image
+
+        im = Image.new('1',
+                       (int(self.barcode_array['num_cols']),
+                        int(self.barcode_array['num_rows'])),
+                       color=1)
+
+        # note: the generated barcode array is inverse, "1" is black, "0" is white.
+
+        pixels = im.load()
+        for r in xrange(int(self.barcode_array['num_rows'])):
+            for c in xrange(int(self.barcode_array['num_cols'])):
+                if self.barcode_array['bcode'][r][c] == "1":
+                    pixels[c, r] = 0
+
+        if scale_x != 1 or scale_y != 1:
+            im = im.resize(
+                (scale_x * int(self.barcode_array['num_cols']),
+                 scale_y * int(self.barcode_array['num_rows'])))
+
+        return im
+
+    def save_to_image_file(self, filename, image_format='png', scale_x=2, scale_y=2):
+        """request to save barcode as a file"""
+        # defaults to double size - for fair comparison to previous png method
+        # TODO - Set defaults for rescale to 1
+
+        self.save_barcode_to_pillow(scale_x=scale_x, scale_y=scale_y).save(filename, format=image_format)


### PR DESCRIPTION
Faster to create an image out of pixels and scale that, in needed.
Creating 1BIT files in black and white speeded up things a lot.

I left in the old version for comparison. Please remove, then change
the default scale to "1"

I added the option to request the pillow object instead of a file -
in my usecase I would not create a file at all but print the barcode instead.

In my tests, text shorter than 5 characters failed to generate a valid pdf417 code,
if you can't see why, you may want to set a minimum length...

I will run automated tests to see if the other generated barcodes are correct.

Hope this helps.
